### PR TITLE
Dark mode enhancement

### DIFF
--- a/_sass/minima/dark-mode.scss
+++ b/_sass/minima/dark-mode.scss
@@ -84,16 +84,11 @@ canvas {
 }
 
 .post-list > li > div {
-    border-radius: 5px !important;
-    box-shadow: 0 3px 6px rgba(149,157,165,0.15) !important;
-    background-color: #212121;
-    border: none;
+    box-shadow: none !important;
+    background-color: inherit;
+    border: none !important;
 }
 
 li .post-meta-description {
-    color: #BDBDBD !important;
-}
-
-.image-preview, .output_png {
-    filter: invert(90%);
+    color: $med-emph !important;
 }

--- a/_sass/minima/dark-mode.scss
+++ b/_sass/minima/dark-mode.scss
@@ -82,3 +82,18 @@ table td{
 canvas {
     filter: invert(100%);
 }
+
+.post-list > li > div {
+    border-radius: 5px !important;
+    box-shadow: 0 3px 6px rgba(149,157,165,0.15) !important;
+    background-color: #212121;
+    border: none;
+}
+
+li .post-meta-description {
+    color: #BDBDBD !important;
+}
+
+.image-preview, .output_png {
+    filter: invert(90%);
+}

--- a/_sass/minima/dark-mode.scss
+++ b/_sass/minima/dark-mode.scss
@@ -84,7 +84,7 @@ canvas {
 }
 
 .post-list > li > div {
-    box-shadow: none !important;
+    background-color: $overlay;
     background-color: inherit;
     border: none !important;
 }


### PR DESCRIPTION
The Dark Mode is inconsistent when you enable vignette for the blog posts by setting `show_image`  to `true` in `_config.yml`. Another inconsistency that I had to face while using Dark Mode was that plots in my notebook didn't appear as I expected them to be when I was using `matplotlib`'s default style. A simple work around for that was to use `ggplot` style and then inverting the plot images.
I also applied `invert` filter to preview images of posts. 
Thank you so much for you contribution  @prampey 
